### PR TITLE
using ucontext on Linux to represent tasks

### DIFF
--- a/examples/1/main.cpp
+++ b/examples/1/main.cpp
@@ -8,7 +8,9 @@ decltask(task1)
 	printf("task1 --- point 1\n"); kernel.relinquish();
 	printf("task1 --- point 2\n"); kernel.relinquish();
 	printf("task1 --- point 3\n"); kernel.relinquish();
+	task1.suspend();
 	task2.resume();
+	kernel.relinquish();
 }
 
 decltask(task2)

--- a/examples/2/main.cpp
+++ b/examples/2/main.cpp
@@ -1,0 +1,55 @@
+#include "rtos.h"
+#include <iostream>
+#include <signal.h>
+#include <sys/time.h>
+
+void tick(int sig, siginfo_t *info, void *ctxt) {
+	std::cout << "tick" << std::endl;
+	kernel.relinquish(0);
+}
+
+
+decltask(scheduler)
+{
+	static rt::task_id_t i = 1;
+	if (i == rt::kernel.ntasks())
+		i = 1;
+	std::cerr << i << std::endl;
+	kernel.set_task(i++);
+}
+
+decltask(task1)
+{
+	while (true)
+		;
+		//printf("task1 --- point 0\n");
+}
+
+decltask(task2)
+{
+	while (true)
+		;
+		//printf("task2 --- point 0\n");
+}
+
+int main()
+{
+	struct sigaction act;
+        act.sa_sigaction = tick;
+        act.sa_flags = SA_RESTART | SA_SIGINFO;
+        sigemptyset(&act.sa_mask);
+        sigaction(SIGALRM, &act, nullptr);
+
+        struct itimerval timtick;
+        timtick.it_interval.tv_sec =    0;
+        timtick.it_interval.tv_usec =   10000; 
+        timtick.it_value = timtick.it_interval;
+        setitimer(ITIMER_REAL, &timtick, nullptr);
+
+	printf("--- started ---\n");
+	rt::kernel.run();
+	printf("--- finished ---\n");
+
+
+	return 0;
+}

--- a/rtoslib/include/kernel_module.h
+++ b/rtoslib/include/kernel_module.h
@@ -8,7 +8,8 @@ namespace rt {
 using PfnTaskRouting = void (*) (void);
 
 class Task final {
-	void start() const { m_context.set();	}
+	void start() const { m_context.set(); }
+	void restart() { start(); } //TODO restart
 	void save_state() { m_context.get(); }
 	void next(const Task &next) {
 		m_context.swap(next.m_context);

--- a/rtoslib/include/kernel_module.h
+++ b/rtoslib/include/kernel_module.h
@@ -8,8 +8,11 @@ namespace rt {
 using PfnTaskRouting = void (*) (void);
 
 class Task final {
-	void start() { m_context.set();	}
+	void start() const { m_context.set();	}
 	void save_state() { m_context.get(); }
+	void next(const Task &next) {
+		m_context.swap(next.m_context);
+	}
 public:
 	Task(const Task& other) = delete;
 	Task(Task&& other) = delete;
@@ -44,11 +47,19 @@ public:
 	void run();
 	void relinquish();
 	void relinquish(task_id_t task_id);
+	void relinquish(Task &task) {
+		relinquish(&task - m_tasks);
+	}
 	void suspend() { current_task().suspend(); }
 
 	task_id_t ntasks() const { return m_ntasks; }
+	task_id_t task_id() const { return m_current_task; }
 	Task& task(task_id_t task_id) { return m_tasks[task_id]; }
 	Task& current_task() { return m_tasks[m_current_task]; }
+	void set_task(task_id_t task_id) {
+		m_current_task = task_id;
+		current_task().start();
+	}
 
 private:
 	Kernel() {}

--- a/rtoslib/include/platform.h
+++ b/rtoslib/include/platform.h
@@ -7,13 +7,30 @@
 
 #ifdef TARGET_LINUX_X86
 	#include <cstddef>
+	#include <csignal>
+	#include <ucontext.h>
 
 	namespace rt {
-
-	using addr_t = size_t;
-	using task_id_t = unsigned int;
-	using task_stack_sz_t = unsigned int;
-
+		using addr_t = void *;
+		using task_id_t = unsigned int;
+		using task_stack_sz_t = unsigned int;
+		
+		class TaskContext {
+		private:
+			ucontext_t m_uc;
+		public:
+			TaskContext(void (*routine_address) (), addr_t stack_addr, task_stack_sz_t stack_size) {
+				getcontext(&m_uc); //TODO possible error;
+				m_uc.uc_stack.ss_sp = stack_addr;
+				m_uc.uc_stack.ss_size = stack_size;
+				m_uc.uc_link = nullptr;
+				sigemptyset(&m_uc.uc_sigmask);
+				makecontext(&m_uc, routine_address, 0);
+			}
+			void set()	{ setcontext(&m_uc); }
+			void get()	{ getcontext(&m_uc); }
+//			void swap()	{ swapcontext(
+		};
 	} // rt namespace end
 #else
 	static_assert(0, SUPPORTED_PLATFORMS);

--- a/rtoslib/include/platform.h
+++ b/rtoslib/include/platform.h
@@ -27,9 +27,15 @@
 				sigemptyset(&m_uc.uc_sigmask);
 				makecontext(&m_uc, routine_address, 0);
 			}
-			void set()	{ setcontext(&m_uc); }
-			void get()	{ getcontext(&m_uc); }
-//			void swap()	{ swapcontext(
+			void set() const {
+				setcontext(&m_uc);
+			}
+			void get() {
+				getcontext(&m_uc);
+			}
+			void swap(const TaskContext &next) {
+				swapcontext(&m_uc, &next.m_uc);
+			}
 		};
 	} // rt namespace end
 #else

--- a/rtoslib/src/kernel_module.cpp
+++ b/rtoslib/src/kernel_module.cpp
@@ -1,35 +1,19 @@
 #include <Mipt-RTOS/kernel_module.h>
-#include <Mipt-RTOS/asm_macro.h>
 
 namespace rt {
 
 void Kernel::run()
 {
-	/*  Declaring task_id before sp variable (i.e. outside loop) in order not
-	 * to change sp after it was acquired. Actually, it shouldn't influence anything,
-	 * but in such way it seems more explicit */
-	task_id_t task_id;
-	addr_t sp = asm_get_stack_pointer();
-
-	for (task_id = 0; task_id < m_ntasks; ++task_id) {
-		m_tasks[task_id].m_stack_starting = sp;
-		sp -= m_tasks[task_id].m_stack_size;
-		/* m_tasks[task_id].m_start_from_begining = true automatically */
-		/* m_tasks[task_id].m_is_suspended = false automatically */
-	}
-
 	m_current_task = 0;
 	m_tasks[0].m_start_from_begining = false;
-	m_tasks[0].m_routine_address();
+	m_tasks[0].start();
 	m_tasks[0].abort();
 	relinquish(); // TODO: think if it is OK
 }
 
 void Kernel::relinquish()
 {
-	asm_pushall();
-	current_task().m_stack_pointer = asm_get_stack_pointer();
-
+	current_task().save_state();
 	while (1) {
 		do {
 			if (++m_current_task == m_ntasks)
@@ -37,12 +21,9 @@ void Kernel::relinquish()
 		} while (current_task().m_is_suspended == true);
 		if (current_task().m_start_from_begining == true) {
 			current_task().m_start_from_begining = false;
-			asm_set_stack_pointer(current_task().m_stack_starting);
-			current_task().m_routine_address();
-			current_task().abort();
+			current_task().start();
 		} else {
-			asm_set_stack_pointer(current_task().m_stack_pointer);
-			asm_popall();
+			current_task().start();
 			return;
 		}
 	}

--- a/rtoslib/src/kernel_module.cpp
+++ b/rtoslib/src/kernel_module.cpp
@@ -29,4 +29,11 @@ void Kernel::relinquish()
 	}
 }
 
+void Kernel::relinquish(task_id_t task_id)
+{
+	auto &task = current_task();
+	m_current_task = task_id;
+	task.next(current_task());
+}
+
 } // rt namespace end

--- a/rtoslib/src/kernel_module.cpp
+++ b/rtoslib/src/kernel_module.cpp
@@ -7,8 +7,8 @@ void Kernel::run()
 	m_current_task = 0;
 	m_tasks[0].m_start_from_begining = false;
 	m_tasks[0].start();
-	m_tasks[0].abort();
-	relinquish(); // TODO: think if it is OK
+	//m_tasks[0].abort();
+	//relinquish(); // TODO: think if it is OK
 }
 
 void Kernel::relinquish()
@@ -20,8 +20,8 @@ void Kernel::relinquish()
 				m_current_task = 0;
 		} while (current_task().m_is_suspended == true);
 		if (current_task().m_start_from_begining == true) {
-			current_task().m_start_from_begining = false;
-			current_task().start();
+			current_task().restart();
+			return;
 		} else {
 			current_task().start();
 			return;


### PR DESCRIPTION
Мб стоит как-то переработать platform.h и вынести реализацию методов TaskContext в cpp, который будет зависим от платформы.
Еще там теперь хотелось бы чтоб сгенереный rtos.cpp содержал определения массивов-стеков (как тут) Я просто не разбирался пока как ты это все генеришь

namespace rt {
  
  Kernel Kernel::m_only_one;
  
const task_id_t Kernel::m_ntasks = 2;
 
char a[4096]; ///////////////////////
char b[1024];/////////////////////////
Task Kernel::m_tasks[Kernel::m_ntasks] = {
       Task(detail::__task1_routine, &a, 4096),
       Task(detail::__task2_routine, &b, 1024)
  };
  
task_id_t Kernel::m_current_task = 0;
  
  } // rt namespace end
~                              